### PR TITLE
Add C++ support to protobuf

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,2 +1,0 @@
-"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
-if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,40 @@
+:: Doesn't include gmock or gtest. So, need to get these ourselves for `make check`.
+git clone -b release-1.7.0 git://github.com/google/googlemock.git gmock
+if errorlevel 1 exit 1
+git clone -b release-1.7.0 git://github.com/google/googletest.git gmock/gtest
+if errorlevel 1 exit 1
+
+:: Setup directory structure per protobuf's instructions.
+cd cmake
+if errorlevel 1 exit 1
+mkdir build
+if errorlevel 1 exit 1
+cd build
+if errorlevel 1 exit 1
+mkdir release
+if errorlevel 1 exit 1
+cd release
+if errorlevel 1 exit 1
+
+:: Configure and install based on protobuf's instructions and other `bld.bat`s.
+cmake -G "NMake Makefiles" ^
+         -DCMAKE_BUILD_TYPE=Release ^
+         -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
+         -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+         -Dprotobuf_WITH_ZLIB=ON ^
+         ../..
+if errorlevel 1 exit 1
+nmake
+if errorlevel 1 exit 1
+nmake check
+if errorlevel 1 exit 1
+nmake install
+if errorlevel 1 exit 1
+
+:: Install the Python portions too.
+cd %SRC_DIR%
+if errorlevel 1 exit 1
+cd python
+if errorlevel 1 exit 1
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
+if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,34 @@
 #!/bin/bash
 
-# Change the permissions of the protobuf.egg-info directory to be 
-# group and world readable
-chmod 644 protobuf.egg-info/*
-$PYTHON setup.py install --single-version-externally-managed --record record.txt
+
+if [ "$(uname)" == "Darwin" ];
+then
+    # Switch to clang with C++11 ASAP.
+    export CC=gcc
+    export CXX=g++
+elif [ "$(uname)" == "Linux" ];
+then
+    export CC=gcc
+    export CXX=g++
+fi
+
+# Doesn't include gmock or gtest. So, need to get these ourselves for `make check`.
+git clone -b release-1.7.0 git://github.com/google/googlemock.git gmock
+git clone -b release-1.7.0 git://github.com/google/googletest.git gmock/gtest
+
+# Build configure/Makefile as they are not present.
+aclocal
+libtoolize
+autoconf
+autoreconf -i
+automake --add-missing
+
+./configure --prefix="${PREFIX}" \
+	    CC="${CC}" \
+	    CXX="${CXX}" \
+	    CXXFLAGS="${CXXFLAGS}" \
+	    LDFLAGS="${LDFLAGS}"
+make
+make check
+make install
+(cd python && python setup.py install --single-version-externally-managed --record record.txt && cd ..)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,8 +4,12 @@
 if [ "$(uname)" == "Darwin" ];
 then
     # Switch to clang with C++11 ASAP.
-    export CC=gcc
-    export CXX=g++
+    export MACOSX_VERSION_MIN=10.7
+    export CC=clang
+    export CXX=clang++
+    export CXXFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN}"
+    export CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -std=c++11"
+    export LIBS="-lc++"
 elif [ "$(uname)" == "Linux" ];
 then
     export CC=gcc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,38 +1,56 @@
-{% set version = "3.0.0b2.post2" %}
+{% set version = "3.0.0b2" %}
+{% set version_str = "v3.0.0-beta-2" %}
 
 package:
     name: protobuf
     version: {{ version }}
 
 source:
-    fn: protobuf-{{ version }}.tar.gz
-    url: https://pypi.python.org/packages/source/p/protobuf/protobuf-{{ version }}.tar.gz
-    md5: 42aa7ab79ebcb94917e938ff482ef7a6
+    fn: protobuf_{{ version }}.tar.gz
+    url: https://github.com/google/protobuf/archive/{{ version_str }}/protobuf-{{ version_str }}.tar.gz
+    md5: e7f2602baffcbc27fb607de659cfbab6
 
 build:
-    number: 2
+    number: 3
+    skip: true  # [win]
 
 requirements:
     build:
+        - autoconf
+        - automake
+        - libtool
+        - pkg-config
         - python
-        - setuptools
+        - six
+        - ordereddict        # [py26]
+        - unittest2          # [py26]
+        - gcc                # [osx]
+        - git
+
     run:
         - python
-        - setuptools
         - six
+        - ordereddict        # [py26]
+        - unittest2          # [py26]
+        - libgcc             # [osx]
 
 test:
+    commands:
+        - protoc --help
+        - test -f ${PREFIX}/lib/libprotobuf.a                # [unix]
+        - test -f ${PREFIX}/lib/libprotobuf.dylib            # [osx]
+        - test -f ${PREFIX}/lib/libprotobuf.so               # [linux]
+
     imports:
         - google
         - google.protobuf
-        - google.protobuf.compiler
         - google.protobuf.internal
         - google.protobuf.pyext
 
 about:
     home: https://developers.google.com/protocol-buffers/
     license: New BSD License
-    summary: 'Protocol Buffers'
+    summary: Protocol Buffers - Google's data interchange format
 
 extra:
     recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,21 +12,27 @@ source:
 
 build:
     number: 3
-    skip: true  # [win]
+    features:
+        - vc9                # [win and py27]
+        - vc10               # [win and py34]
+        - vc14               # [win and py35]
 
 requirements:
     build:
-        - autoconf
-        - automake
-        - libtool
-        - pkg-config
+        - git
+        - cmake              # [win]
+        - autoconf           # [unix]
+        - automake           # [unix]
+        - libtool            # [unix]
+        - pkg-config         # [unix]
+        - zlib
         - python
         - six
         - ordereddict        # [py26]
         - unittest2          # [py26]
-        - git
 
     run:
+        - zlib
         - python
         - six
         - ordereddict        # [py26]
@@ -35,9 +41,10 @@ requirements:
 test:
     commands:
         - protoc --help
-        - test -f ${PREFIX}/lib/libprotobuf.a                # [unix]
-        - test -f ${PREFIX}/lib/libprotobuf.dylib            # [osx]
-        - test -f ${PREFIX}/lib/libprotobuf.so               # [linux]
+        - test -f ${PREFIX}/lib/libprotobuf.a                           # [unix]
+        - test -f ${PREFIX}/lib/libprotobuf.dylib                       # [osx]
+        - test -f ${PREFIX}/lib/libprotobuf.so                          # [linux]
+        - if not exist %PREFIX%\\Library\\lib\\libprotobuf.lib exit 1   # [win]
 
     imports:
         - google

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.0.0b2" %}
+{% set version = "3.0.0b2.post2" %}
 {% set version_str = "v3.0.0-beta-2" %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,6 @@ requirements:
         - six
         - ordereddict        # [py26]
         - unittest2          # [py26]
-        - gcc                # [osx]
         - git
 
     run:
@@ -32,7 +31,6 @@ requirements:
         - six
         - ordereddict        # [py26]
         - unittest2          # [py26]
-        - libgcc             # [osx]
 
 test:
     commands:


### PR DESCRIPTION
This proposes to build Python and C++ support for protobuf. Thus it can include things like the protobuf compiler. However, build issues on Mac forced us to return to the most recent 2.x version. Trying to recover this was getting a bit tricky, but the plan is to get this working again with 3.x.

* [x] Build the protobuf compiler `protoc`.
* [x] Build C++ support.
* [x] Add back Windows support.
* [x] Recover 3.0.0 beta 2 support.
* [x] Decide on version/build number.