### PR TITLE
Update to version 3.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,16 @@
-{% set version = "3.0.0b3" %}
-{% set version_str = "v3.0.0-beta-3" %}
+{% set name = "protobuf" %}
+{% set version = "3.0.0" %}
+{% set version_str = "v3.0.0" %}
+{% set sha256 = "f5b3563f118f1d3d6e001705fa7082e8fc3bda50038ac3dff787650795734146" %}
 
 package:
-    name: protobuf
+    name: {{ name }}
     version: {{ version }}
 
 source:
-    fn: protobuf_{{ version }}.tar.gz
-    url: https://github.com/google/protobuf/archive/{{ version_str }}/protobuf-{{ version_str }}.tar.gz
-    md5: 89afd3855f2d4782e59c09e07d9efa67
+    fn: {{ name }}-{{ version }}.tar.gz
+    url: https://github.com/google/protobuf/archive/{{ version_str }}/{{ name }}-{{ version_str }}.tar.gz
+    sha256: {{ sha256 }}
 
 build:
     number: 1


### PR DESCRIPTION
Changed the filename attribute in the metal.yaml to be consistent with what I've seen in other recipies. However is this isn't right for this repo, then happy to revert that.

Switched to `sha256` instead of `md5`. I'm not a security/cyrpto expert, but from what I understand md5 isn't broken for the usecase of generated a filechecksum, however I thought it's easier to simply not worry and use a stronger hash. Again happy to revert if someone has an issue with that.