### PR TITLE
Support protobuf 3.5 on Windows Python 2.7

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,14 @@ environment:
 
   matrix:
     - TARGET_ARCH: x86
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
+
+    - TARGET_ARCH: x86
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35
 

--- a/recipe/PR_4074.patch
+++ b/recipe/PR_4074.patch
@@ -1,0 +1,22 @@
+From 501093d778258197cb8eec10d31cc9497520e459 Mon Sep 17 00:00:00 2001
+From: Jisi Liu <jisi.liu@gmail.com>
+Date: Tue, 19 Dec 2017 12:20:13 -0800
+Subject: [PATCH] Replace C++11 only method std::map::at
+
+---
+ src/google/protobuf/util/field_mask_util.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git src/google/protobuf/util/field_mask_util.cc src/google/protobuf/util/field_mask_util.cc
+index 4d0d3a46a5..8a41349875 100644
+--- src/google/protobuf/util/field_mask_util.cc
++++ src/google/protobuf/util/field_mask_util.cc
+@@ -374,7 +374,7 @@ void FieldMaskTree::RemovePath(const string& path,
+       }
+     }
+     if (ContainsKey(node->children, parts[i])) {
+-      node = node->children.at(parts[i]);
++      node = node->children[parts[i]];
+       if (field_descriptor->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE) {
+         current_descriptor = field_descriptor->message_type();
+       }

--- a/recipe/PR_4076.patch
+++ b/recipe/PR_4076.patch
@@ -1,0 +1,22 @@
+From 19d0e9934c997b1dc46ad539c37d67ea6c6fc33f Mon Sep 17 00:00:00 2001
+From: Jisi Liu <jisi.liu@gmail.com>
+Date: Tue, 19 Dec 2017 15:23:37 -0800
+Subject: [PATCH] Fix string::back() usage in googletest.cc
+
+---
+ src/google/protobuf/testing/googletest.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git src/google/protobuf/testing/googletest.cc src/google/protobuf/testing/googletest.cc
+index c329b6c1e5..b81d3994b7 100644
+--- src/google/protobuf/testing/googletest.cc
++++ src/google/protobuf/testing/googletest.cc
+@@ -132,7 +132,7 @@ string GetTemporaryDirectoryName() {
+   // with "\\?\") but these will be degenerate in the sense that you cannot
+   // chdir into such directories (or navigate into them with Windows Explorer)
+   // nor can you open such files with some programs (e.g. Notepad).
+-  if (result.back() == '.') {
++  if (result[result.size() - 1] == '.') {
+     result[result.size() - 1] = '_';
+   }
+   // On Win32, tmpnam() returns a file prefixed with '\', but which is supposed

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,15 @@ package:
 source:
   url: https://github.com/google/protobuf/archive/v{{ version }}/{{ name }}-v{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    #######################################################
+    # Apply patches for pre-C++11 compilers.              #
+    #                                                     #
+    # xref: https://github.com/google/protobuf/pull/4074  #
+    # xref: https://github.com/google/protobuf/pull/4076  #
+    #######################################################
+    - PR_4074.patch
+    - PR_4076.patch
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 
 build:
   number: 0
-  skip: True  # [win and py27]
   features:
     - vc9  # [win and py27]
     - vc10  # [win and py34]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     - PR_4076.patch
 
 build:
-  number: 0
+  number: 1
   features:
     - vc9  # [win and py27]
     - vc10  # [win and py34]


### PR DESCRIPTION
Attempts to re-enable Windows Python 2.7 on protobuf 3.5.