### PR TITLE
Include compiler and util packages in distribution

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -36,5 +36,17 @@ cd %SRC_DIR%
 if errorlevel 1 exit 1
 cd python
 if errorlevel 1 exit 1
+
+:: Begin fix for missing packages issue: https://github.com/conda-forge/protobuf-feedstock/issues/40
+if not exist "google/protobuf/util" mkdir "google/protobuf/util"
+if errorlevel 1 exit 1
+if not exist "google/protobuf/compiler" mkdir "google/protobuf/compiler"
+if errorlevel 1 exit 1
+type nul >> "google/protobuf/util/__init__.py"
+if errorlevel 1 exit 1
+type nul >> "google/protobuf/compiler/__init__.py"
+if errorlevel 1 exit 1
+:: End fix
+
 "%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,4 +20,15 @@ fi
 make -j ${CPU_COUNT}
 make check -j ${CPU_COUNT}
 make install
-(cd python && python setup.py install --cpp_implementation --single-version-externally-managed --record record.txt && cd ..)
+
+# Install python package now
+cd python
+
+# Begin fix for missing packages issue: https://github.com/conda-forge/protobuf-feedstock/issues/40
+mkdir -p google/protobuf/util
+mkdir -p google/protobuf/compiler
+touch google/protobuf/util/__init__.py
+touch google/protobuf/compiler/__init__.py
+# End fix
+
+python setup.py install --cpp_implementation --single-version-externally-managed --record record.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - PR_4124.patch
 
 build:
-  number: 2
+  number: 3
   features:
     - vc9  # [win and py27]
     - vc10  # [win and py34]
@@ -64,6 +64,8 @@ test:
     - google.protobuf
     - google.protobuf.internal
     - google.protobuf.pyext
+    - google.protobuf.util
+    - google.protobuf.compiler
 
 about:
   home: https://developers.google.com/protocol-buffers/


### PR DESCRIPTION
Fixes issue https://github.com/conda-forge/protobuf-feedstock/issues/40, replacing failed attempt using patch files https://github.com/conda-forge/protobuf-feedstock/pull/41.

This brings the conda package in line with pypi in that you can now import the `google.protobuf.util` and `google.protobuf.compiler` packages. Truthfully, the use of these packages evades me a bit (`compiler` seems experimental and `util` seems like its just for unit tests), but as this is matching the pypi experience I think it's an improvement. 

I tried to make this work via a patch file, but failed. Instead, I resorted to editing the build.sh and build.bat files. 

@jakirkham could you review this?