### PR TITLE
Support protobuf 3.5.1 on Windows Python 2.7

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,14 @@ environment:
 
   matrix:
     - TARGET_ARCH: x86
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
+
+    - TARGET_ARCH: x86
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35
 

--- a/recipe/PR_4124.patch
+++ b/recipe/PR_4124.patch
@@ -1,0 +1,22 @@
+From 4f3d8657c3914e5f2d5aa992e26f3e5c09326b84 Mon Sep 17 00:00:00 2001
+From: Jisi Liu <jisi.liu@gmail.com>
+Date: Tue, 2 Jan 2018 14:13:54 -0800
+Subject: [PATCH] remove nullptr
+
+---
+ src/google/protobuf/stubs/io_win32.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git src/google/protobuf/stubs/io_win32.cc src/google/protobuf/stubs/io_win32.cc
+index ad2d2d265e..b59b8e487b 100644
+--- src/google/protobuf/stubs/io_win32.cc
++++ src/google/protobuf/stubs/io_win32.cc
+@@ -91,7 +91,7 @@ struct CharTraits<wchar_t> {
+ 
+ template <typename char_type>
+ bool null_or_empty(const char_type* s) {
+-  return s == nullptr || *s == 0;
++  return s == NULL || *s == 0;
+ }
+ 
+ // Returns true if the path starts with a drive letter, e.g. "c:".

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,13 @@ package:
 source:
   url: https://github.com/google/protobuf/archive/v{{ version }}/{{ name }}-v{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    #######################################################
+    # Apply patches for pre-C++11 compilers.              #
+    #                                                     #
+    # xref: https://github.com/google/protobuf/pull/4124  #
+    #######################################################
+    - PR_4124.patch
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 
 build:
   number: 0
-  skip: True  # [win and py27]
   features:
     - vc9  # [win and py27]
     - vc10  # [win and py34]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - PR_4124.patch
 
 build:
-  number: 0
+  number: 1
   features:
     - vc9  # [win and py27]
     - vc10  # [win and py34]


### PR DESCRIPTION
Attempts to re-enable Windows Python 2.7 on protobuf 3.5.1.