### PR TITLE
protobuf 4.23.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 # keep this without major version to let the bot pick it up
-{% set version = "23.1" %}
+{% set version = "23.2" %}
 # protobuf doesn't add the major version in the tag, it's defined per language in
 # https://github.com/protocolbuffers/protobuf/blob/main/version.json
 {% set major = "4" %}
@@ -12,7 +12,7 @@ package:
 
 source:
   url: https://github.com/protocolbuffers/protobuf/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: dc167b7d23ec0d6e4a3d4eae1798de6c8d162e69fa136d39753aaeb7a6e1289d
+  sha256: 0b0395d34e000f1229679e10d984ed7913078f3dd7f26cf0476467f5e65716f4
   patches:
     - patches/0001-do-not-link-msvc-runtime-statically.patch
     - patches/0002-fix-paths-for-include-lib-directories.patch
@@ -23,7 +23,7 @@ source:
     - patches/0007-be-more-lenient-with-abseil-version.patch
 
 build:
-  number: 1
+  number: 0
   script:
     - cd python
     - export PROTOC=$PREFIX/bin/protoc        # [unix and (build_platform == target_platform)]


### PR DESCRIPTION
Should wait for the builds of https://github.com/conda-forge/protobuf-feedstock/pull/188 to land