### PR TITLE
[v4.24.3] Reinstate PyPy

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 # keep this without major version to let the bot pick it up
-{% set version = "24.4" %}
+{% set version = "24.3" %}
 # protobuf doesn't add the major version in the tag, it's defined per language in
 # https://github.com/protocolbuffers/protobuf/blob/main/version.json
 {% set major = "4" %}
@@ -12,7 +12,7 @@ package:
 
 source:
   url: https://github.com/protocolbuffers/protobuf/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 616bb3536ac1fff3fb1a141450fa28b875e985712170ea7f1bfe5e5fc41e2cd8
+  sha256: 07d69502e58248927b58c7d7e7424135272ba5b2852a753ab6b67e62d2d29355
   patches:
     - patches/0001-do-not-link-msvc-runtime-statically.patch
     - patches/0002-fix-paths-for-include-lib-directories.patch
@@ -21,7 +21,7 @@ source:
     - patches/0005-set-PROTOBUF_USE_DLLS-on-windows.patch
 
 build:
-  number: 0
+  number: 1
   script:
     - cd python
     - export PROTOC=$PREFIX/bin/protoc        # [unix and (build_platform == target_platform)]


### PR DESCRIPTION
Do #203 but for 4.24.3. Not every patch version is worth a branch though, so we just revert the version bump for now.