### PR TITLE
fix pip check (and test it)

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -37,12 +37,4 @@ export BAZEL="$(pwd)/../bazel-standalone"
     //python/dist:binary_wheel \
     --define=use_fast_cpp_protos=true
 
-# The wheel tags are only semi-important. We need to rename them to a filename that `pip` will accept.
-# We don't modify any of the internal metadata.
-if [[ "${target_platform}" == "linux-ppc64le" ]]; then
-  mv ../bazel-bin/python/dist/protobuf-${PKG_VERSION}-*.whl ../bazel-bin/python/dist/protobuf-${PKG_VERSION}-cp${PY_VER/./}-cp${PY_VER/./}-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl
-fi
-if [[ "${target_platform}" == "osx-64" ]]; then
-  mv ../bazel-bin/python/dist/protobuf-${PKG_VERSION}-*.whl ../bazel-bin/python/dist/protobuf-${PKG_VERSION}-cp${PY_VER/./}-cp${PY_VER/./}-macosx_10_13_x86_64.whl
-fi
 python -m pip install ../bazel-bin/python/dist/protobuf-${PKG_VERSION}-*.whl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ source:
       - patches/0005-Support-more-architectures-for-Python-bindings.patch
       - patches/0006-Compatible-windows-changes.patch
       - patches/0007-Hacky-windows-workarounds.patch  # [win]
+      - patches/0008-Add-osx-64-and-linux-ppc64le-as-supported-wheel-tags.patch
   {% set bz_url = "https://github.com/bazelbuild/bazel/releases/download" %}
   {% set bz_ver = "6.5.0" %}
   - fn: bazel-standalone    # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ source:
     sha256: 6eae8e7f28e1b68b833503d1a58caf139c11e52de19df0d787d974653a0ea4c6    # [build_platform == "win-64"]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,6 +63,8 @@ requirements:
     - libprotobuf {{ lib_major ~ "." ~ version }}
 
 test:
+  requires:
+    - pip
   imports:
     - google
     - google.protobuf
@@ -73,6 +75,7 @@ test:
     - google.protobuf.compiler
   commands:
     - python -c "from google.protobuf.internal import api_implementation; assert api_implementation.Type() == 'upb'"
+    - pip check
 
 about:
   home: https://developers.google.com/protocol-buffers/

--- a/recipe/patches/0008-Add-osx-64-and-linux-ppc64le-as-supported-wheel-tags.patch
+++ b/recipe/patches/0008-Add-osx-64-and-linux-ppc64le-as-supported-wheel-tags.patch
@@ -1,0 +1,52 @@
+From 446f350a015b9d8b539a0092e6cac2ded5c2ff6b Mon Sep 17 00:00:00 2001
+From: Uwe Korn <uwelk@xhochy.com>
+Date: Mon, 23 Sep 2024 11:59:53 +0000
+Subject: [PATCH] Add osx-64 and linux-ppc64le as supported wheel tags
+
+---
+ python/dist/BUILD.bazel | 22 ++++++++++++++++++++++
+ 1 file changed, 22 insertions(+)
+
+diff --git a/python/dist/BUILD.bazel b/python/dist/BUILD.bazel
+index 457302c..edcedd3 100644
+--- a/python/dist/BUILD.bazel
++++ b/python/dist/BUILD.bazel
+@@ -65,6 +65,25 @@ config_setting(
+     },
+ )
+ 
++config_setting(
++    name = "linux_ppc64le_release",
++    flag_values = {
++        "//toolchain:release": "True",
++    },
++    values = {"cpu": "linux-ppc64le"},
++)
++
++config_setting(
++    name = "linux_ppc64le_local",
++    constraint_values = [
++        "@platforms//os:linux",
++        "@platforms//cpu:ppc64le",
++    ],
++    flag_values = {
++        "//toolchain:release": "False",
++    },
++)
++
+ config_setting(
+     name = "linux_x86_64_release",
+     flag_values = {
+@@ -325,9 +344,12 @@ py_wheel(
+     platform = select({
+         ":linux_x86_64_local": "linux_x86_64",
+         ":linux_x86_64_release": "manylinux2014_x86_64",
++        ":linux_ppc64le_local": "linux_ppc64le",
++        ":linux_ppc64le_release": "manylinux2014_ppc64le",
+         ":linux_aarch64_local": "linux_aarch64",
+         ":linux_aarch64_release": "manylinux2014_aarch64",
+         ":osx_universal2": "macosx_10_9_universal2",
++        ":osx_x86_64": "macosx_10_13_x86_64",
+         ":osx_aarch64": "macosx_11_0_arm64",
+         ":windows_x86_32": "win32",
+         ":windows_x86_64": "win_amd64",


### PR DESCRIPTION
Seeing failures on osx for grpc with:
```
+ python -m pip check
protobuf 5.26.1 is not supported on this platform
```

Closes #225