### PR TITLE
protobuf v6.31.1

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-alma-x86_64:8
 libabseil:
-- '20250127'
+- '20250512'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-alma-x86_64:8
 libabseil:
-- '20250127'
+- '20250512'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-alma-x86_64:8
 libabseil:
-- '20250127'
+- '20250512'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_python3.13.____cp313.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-alma-x86_64:8
 libabseil:
-- '20250127'
+- '20250512'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-alma-x86_64:8
 libabseil:
-- '20250127'
+- '20250512'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-alma-x86_64:8
 libabseil:
-- '20250127'
+- '20250512'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-alma-x86_64:8
 libabseil:
-- '20250127'
+- '20250512'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-alma-x86_64:8
 libabseil:
-- '20250127'
+- '20250512'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_python3.13.____cp313.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-alma-x86_64:8
 libabseil:
-- '20250127'
+- '20250512'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.9.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-alma-x86_64:8
 libabseil:
-- '20250127'
+- '20250512'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-alma-x86_64:8
 libabseil:
-- '20250127'
+- '20250512'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-alma-x86_64:8
 libabseil:
-- '20250127'
+- '20250512'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-alma-x86_64:8
 libabseil:
-- '20250127'
+- '20250512'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_python3.13.____cp313.yaml
+++ b/.ci_support/linux_ppc64le_python3.13.____cp313.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-alma-x86_64:8
 libabseil:
-- '20250127'
+- '20250512'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.9.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-alma-x86_64:8
 libabseil:
-- '20250127'
+- '20250512'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/migrations/absl_grpc_proto_25Q2.yaml
+++ b/.ci_support/migrations/absl_grpc_proto_25Q2.yaml
@@ -1,0 +1,42 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for libabseil 20250512, libgrpc 1.73 & libprotobuf 6.31.1
+  kind: version
+  migration_number: 1
+  paused: true
+  exclude:
+    - abseil-cpp
+    - grpc-cpp
+    - libprotobuf
+    - protobuf
+    - re2
+  ordering:
+    # see below
+    c_compiler:
+    - vs2019
+    - vs
+    cxx_compiler:
+    - vs2019
+    - vs
+libabseil:
+- 20250512
+libgrpc:
+- "1.73"
+libprotobuf:
+- 6.31.1
+# we need to leave this migration open until we're ready to move the global baseline, see
+# https://github.com/conda-forge/conda-forge.github.io/issues/2467; grpc 1.72 requires 11.0,
+# see https://github.com/grpc/grpc/commit/f122d248443c81592e748da1adb240cbf0a0231c
+c_stdlib_version:   # [osx]
+  - 11.0            # [osx]
+# newest abseil runs into an ICE on vs2019, so we need a newer toolchain; this is a temporary
+# work-around, pending https://github.com/conda-forge/conda-forge.github.io/issues/2138
+c_compiler:             # [win]
+  - vs                  # [win]
+cxx_compiler:           # [win]
+  - vs                  # [win]
+c_compiler_version:     # [win]
+  - 2022                # [win]
+cxx_compiler_version:   # [win]
+  - 2022                # [win]
+migrator_ts: 1748506837.6039238

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.14'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.14'
+- '11.0'
 c_compiler:
 - clang
 c_compiler_version:
@@ -9,7 +9,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.14'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '18'
 libabseil:
-- '20250127'
+- '20250512'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.14'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.14'
+- '11.0'
 c_compiler:
 - clang
 c_compiler_version:
@@ -9,7 +9,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.14'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '18'
 libabseil:
-- '20250127'
+- '20250512'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_python3.12.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.14'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.14'
+- '11.0'
 c_compiler:
 - clang
 c_compiler_version:
@@ -9,7 +9,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.14'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '18'
 libabseil:
-- '20250127'
+- '20250512'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_python3.13.____cp313.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.14'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.14'
+- '11.0'
 c_compiler:
 - clang
 c_compiler_version:
@@ -9,7 +9,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.14'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '18'
 libabseil:
-- '20250127'
+- '20250512'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.14'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.14'
+- '11.0'
 c_compiler:
 - clang
 c_compiler_version:
@@ -9,7 +9,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.14'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '18'
 libabseil:
-- '20250127'
+- '20250512'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '18'
 libabseil:
-- '20250127'
+- '20250512'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '18'
 libabseil:
-- '20250127'
+- '20250512'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '18'
 libabseil:
-- '20250127'
+- '20250512'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '18'
 libabseil:
-- '20250127'
+- '20250512'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '18'
 libabseil:
-- '20250127'
+- '20250512'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -1,5 +1,7 @@
 c_compiler:
-- vs2019
+- vs
+c_compiler_version:
+- '2022'
 c_stdlib:
 - vs
 channel_sources:
@@ -7,7 +9,9 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2019
+- vs
+cxx_compiler_version:
+- '2022'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -1,5 +1,7 @@
 c_compiler:
-- vs2019
+- vs
+c_compiler_version:
+- '2022'
 c_stdlib:
 - vs
 channel_sources:
@@ -7,7 +9,9 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2019
+- vs
+cxx_compiler_version:
+- '2022'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -1,5 +1,7 @@
 c_compiler:
-- vs2019
+- vs
+c_compiler_version:
+- '2022'
 c_stdlib:
 - vs
 channel_sources:
@@ -7,7 +9,9 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2019
+- vs
+cxx_compiler_version:
+- '2022'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.13.____cp313.yaml
+++ b/.ci_support/win_64_python3.13.____cp313.yaml
@@ -1,5 +1,7 @@
 c_compiler:
-- vs2019
+- vs
+c_compiler_version:
+- '2022'
 c_stdlib:
 - vs
 channel_sources:
@@ -7,7 +9,9 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2019
+- vs
+cxx_compiler_version:
+- '2022'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -1,5 +1,7 @@
 c_compiler:
-- vs2019
+- vs
+c_compiler_version:
+- '2022'
 c_stdlib:
 - vs
 channel_sources:
@@ -7,7 +9,9 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2019
+- vs
+cxx_compiler_version:
+- '2022'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -12,7 +12,7 @@ source .scripts/logging_utils.sh
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
-PROVIDER_DIR="$(basename $THISDIR)"
+PROVIDER_DIR="$(basename "$THISDIR")"
 
 FEEDSTOCK_ROOT="$( cd "$( dirname "$0" )/.." >/dev/null && pwd )"
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -25,7 +25,7 @@ set "MICROMAMBA_EXE=%MICROMAMBA_TMPDIR%\micromamba.exe"
 
 echo Downloading micromamba %MICROMAMBA_VERSION%
 if not exist "%MICROMAMBA_TMPDIR%" mkdir "%MICROMAMBA_TMPDIR%"
-certutil -urlcache -split -f "%MICROMAMBA_URL%" "%MICROMAMBA_EXE%"
+powershell -ExecutionPolicy Bypass -Command "(New-Object Net.WebClient).DownloadFile('%MICROMAMBA_URL%', '%MICROMAMBA_EXE%')"
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 echo Creating environment

--- a/build-locally.py
+++ b/build-locally.py
@@ -10,6 +10,7 @@ import glob
 import os
 import platform
 import subprocess
+import sys
 from argparse import ArgumentParser
 
 
@@ -44,10 +45,19 @@ def run_osx_build(ns):
     subprocess.check_call([script])
 
 
+def run_win_build(ns):
+    script = ".scripts/run_win_build.bat"
+    subprocess.check_call(["cmd", "/D", "/Q", "/C", f"CALL {script}"])
+
+
 def verify_config(ns):
+    choices_filter = ns.filter or "*"
     valid_configs = {
-        os.path.basename(f)[:-5] for f in glob.glob(".ci_support/*.yaml")
+        os.path.basename(f)[:-5]
+        for f in glob.glob(f".ci_support/{choices_filter}.yaml")
     }
+    if choices_filter != "*":
+        print(f"filtering for '{choices_filter}.yaml' configs")
     print(f"valid configs are {valid_configs}")
     if ns.config in valid_configs:
         print("Using " + ns.config + " configuration")
@@ -60,30 +70,37 @@ def verify_config(ns):
         selections = list(enumerate(sorted(valid_configs), 1))
         for i, c in selections:
             print(f"{i}. {c}")
-        s = input("\n> ")
+        try:
+            s = input("\n> ")
+        except KeyboardInterrupt:
+            print("\nno option selected, bye!", file=sys.stderr)
+            sys.exit(1)
         idx = int(s) - 1
         ns.config = selections[idx][1]
         print(f"selected {ns.config}")
     else:
         raise ValueError("config " + ns.config + " is not valid")
-    # Remove the following, as implemented
-    if ns.config.startswith("win"):
-        raise ValueError(
-            f"only Linux/macOS configs currently supported, got {ns.config}"
+    if (
+        ns.config.startswith("osx")
+        and platform.system() == "Darwin"
+        and not os.environ.get("OSX_SDK_DIR")
+    ):
+        raise RuntimeError(
+            "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+            "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+            "Note: OSX_SDK_DIR must be set to an absolute path. "
+            "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
         )
-    elif ns.config.startswith("osx"):
-        if "OSX_SDK_DIR" not in os.environ:
-            raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
-                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
-                "Note: OSX_SDK_DIR must be set to an absolute path. "
-                "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
-            )
 
 
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--filter",
+        default=None,
+        help="Glob string to filter which build choices are presented in interactive mode.",
+    )
     p.add_argument(
         "--debug",
         action="store_true",
@@ -104,6 +121,8 @@ def main(args=None):
             run_docker_build(ns)
         elif ns.config.startswith("osx"):
             run_osx_build(ns)
+        elif ns.config.startswith("win"):
+            run_win_build(ns)
     finally:
         recipe_license_file = os.path.join(
             "recipe", "recipe-scripts-license.txt"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,10 @@
 # keep this without major version to let the bot pick it up
-{% set version = "29.3" %}
+{% set version = "30.2" %}
 # protobuf doesn't add the major version in the tag, it's defined per language in
 # https://github.com/protocolbuffers/protobuf/blob/main/version.json
-{% set major = "5" %}
+{% set major = "6" %}
 # libprotobuf can have a different major version than protobuf
-{% set lib_major = "5" %}
+{% set lib_major = "6" %}
 
 package:
   name: protobuf
@@ -12,7 +12,7 @@ package:
 
 source:
   - url: https://github.com/protocolbuffers/protobuf/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: 008a11cc56f9b96679b4c285fd05f46d317d685be3ab524b2a310be0fbad987e
+    sha256: 07a43d88fe5a38e434c7f94129cad56a4c43a51f99336074d0799c2f7d4e44c5
     patches:
       # backport https://github.com/protocolbuffers/protobuf/pull/17207 to avoid upb leakage
       - patches/0001-Make-our-Python-source-wheel-use-the-version-script-.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 # keep this without major version to let the bot pick it up
-{% set version = "30.2" %}
+{% set version = "31.1" %}
 # protobuf doesn't add the major version in the tag, it's defined per language in
 # https://github.com/protocolbuffers/protobuf/blob/main/version.json
 {% set major = "6" %}
@@ -12,7 +12,7 @@ package:
 
 source:
   - url: https://github.com/protocolbuffers/protobuf/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: 07a43d88fe5a38e434c7f94129cad56a4c43a51f99336074d0799c2f7d4e44c5
+    sha256: c3a0a9ece8932e31c3b736e2db18b1c42e7070cd9b881388b26d01aa71e24ca2
     patches:
       # backport https://github.com/protocolbuffers/protobuf/pull/17207 to avoid upb leakage
       - patches/0001-Make-our-Python-source-wheel-use-the-version-script-.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,17 +27,17 @@ source:
       - patches/0009-unvendor-abseil-zlib.patch                                     # [not win]
 
   {% set bz_url = "https://github.com/bazelbuild/bazel/releases/download" %}
-  {% set bz_ver = "6.5.0" %}
+  {% set bz_ver = "7.2.1" %}
   - fn: bazel-standalone    # [unix]
   - fn: bazel.exe           # [win]
     url: {{ bz_url }}/{{ bz_ver }}/bazel_nojdk-{{ bz_ver }}-linux-x86_64        # [build_platform == "linux-64"]
-    sha256: 218ce0aed544d29084f4d9ff98f01bc784b90fe4c79dab63fa990dc68e66eaa9    # [build_platform == "linux-64"]
+    sha256: 1c7a167ad2c45374afb19f60093465f58f9209a5142d53d63bc4aadb567323fa    # [build_platform == "linux-64"]
     url: {{ bz_url }}/{{ bz_ver }}/bazel_nojdk-{{ bz_ver }}-darwin-x86_64       # [build_platform == "osx-64"]
-    sha256: ccc67fa48a6444818a5b85e8174c89ca2630df60c1e2327714d944035a240fc9    # [build_platform == "osx-64"]
+    sha256: ba0a10ecbdaa70bf348bfdbad2fbcf0ba926a5ee07b613f6656046a1d3f60e07    # [build_platform == "osx-64"]
     url: {{ bz_url }}/{{ bz_ver }}/bazel_nojdk-{{ bz_ver }}-darwin-arm64        # [build_platform == "osx-arm64"]
-    sha256: 37017223885da29d8c42be781e8c11b84e71a3d9355b073d43b08a5dfa99229a    # [build_platform == "osx-arm64"]
+    sha256: ef15ff2c9ca3cbf2b09dcc88ea6d7d89575cfd6904e560d7691831a1d7daaf82    # [build_platform == "osx-arm64"]
     url: {{ bz_url }}/{{ bz_ver }}/bazel-{{ bz_ver }}-windows-x86_64.exe        # [build_platform == "win-64"]
-    sha256: 6eae8e7f28e1b68b833503d1a58caf139c11e52de19df0d787d974653a0ea4c6    # [build_platform == "win-64"]
+    sha256: 4926bd3bf580b8b3323e0d09bde5dc6120fdd262d99f753eb61fedfb9a2cfc49    # [build_platform == "win-64"]
 
 build:
   number: 0

--- a/recipe/patches/0001-Make-our-Python-source-wheel-use-the-version-script-.patch
+++ b/recipe/patches/0001-Make-our-Python-source-wheel-use-the-version-script-.patch
@@ -1,4 +1,4 @@
-From fd30b39adc98454991cbf5e80192cf39cc669584 Mon Sep 17 00:00:00 2001
+From c4812f273a9c4977ddb4cef3840532aafbfbf7de Mon Sep 17 00:00:00 2001
 From: Joshua Haberman <haberman@google.com>
 Date: Fri, 21 Jun 2024 11:12:25 -0700
 Subject: [PATCH 1/9] Make our Python source wheel use the version script to
@@ -17,10 +17,10 @@ PiperOrigin-RevId: 645445353
  4 files changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/python/BUILD.bazel b/python/BUILD.bazel
-index 6131ab92c..956e5341e 100644
+index 3a13a97e3..813bf0c1d 100644
 --- a/python/BUILD.bazel
 +++ b/python/BUILD.bazel
-@@ -164,6 +164,8 @@ filegroup(
+@@ -136,6 +136,8 @@ filegroup(
      ],
  )
  
@@ -30,10 +30,10 @@ index 6131ab92c..956e5341e 100644
      name = "_message",
      srcs = [":message_srcs"],
 diff --git a/python/dist/BUILD.bazel b/python/dist/BUILD.bazel
-index 764fc7054..ee07c735e 100644
+index e7d32cb1f..d1b654844 100644
 --- a/python/dist/BUILD.bazel
 +++ b/python/dist/BUILD.bazel
-@@ -239,6 +239,7 @@ pkg_files(
+@@ -260,6 +260,7 @@ pkg_files(
      srcs = [
          "//:LICENSE",
          "//python:message_srcs",
@@ -52,7 +52,7 @@ index 1b619364e..f243c1018 100644
 +global-include *.inc
 +include python/version_script.lds
 diff --git a/python/dist/setup.py b/python/dist/setup.py
-index 3ace6a881..0868deba4 100755
+index 4a92a4de1..f00d9fbfd 100755
 --- a/python/dist/setup.py
 +++ b/python/dist/setup.py
 @@ -32,7 +32,7 @@ def GetVersion():

--- a/recipe/patches/0002-don-t-mark-windows-as-unsupported.patch
+++ b/recipe/patches/0002-don-t-mark-windows-as-unsupported.patch
@@ -1,4 +1,4 @@
-From 44def1d302eab8155f2900d2cd38331b0e56e81f Mon Sep 17 00:00:00 2001
+From 7edd5abd4ad384d4470b1d73068bbc5c2b09ab46 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sat, 29 Jun 2024 09:49:55 +1100
 Subject: [PATCH 2/9] don't mark windows as unsupported
@@ -8,10 +8,10 @@ Subject: [PATCH 2/9] don't mark windows as unsupported
  1 file changed, 1 deletion(-)
 
 diff --git a/python/BUILD.bazel b/python/BUILD.bazel
-index 956e5341e..0d2254394 100644
+index 813bf0c1d..c0bf90214 100644
 --- a/python/BUILD.bazel
 +++ b/python/BUILD.bazel
-@@ -131,7 +131,6 @@ selects.config_setting_group(
+@@ -103,7 +103,6 @@ selects.config_setting_group(
  )
  
  _message_target_compatible_with = {

--- a/recipe/patches/0003-don-t-link-statically-on-windows.patch
+++ b/recipe/patches/0003-don-t-link-statically-on-windows.patch
@@ -1,4 +1,4 @@
-From 3a815f71590ab7772c6f242ff82d7dccc29ebd1f Mon Sep 17 00:00:00 2001
+From 1aeec33598d70f70ae1726349b7fb897307d0341 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sat, 29 Jun 2024 09:50:18 +1100
 Subject: [PATCH 3/9] don't link statically on windows
@@ -8,7 +8,7 @@ Subject: [PATCH 3/9] don't link statically on windows
  1 file changed, 3 deletions(-)
 
 diff --git a/python/dist/setup.py b/python/dist/setup.py
-index 0868deba4..29184f065 100755
+index f00d9fbfd..a46ffa36f 100755
 --- a/python/dist/setup.py
 +++ b/python/dist/setup.py
 @@ -34,9 +34,6 @@ def GetVersion():

--- a/recipe/patches/0004-enable-windows-as-a-target-for-python-bindings.patch
+++ b/recipe/patches/0004-enable-windows-as-a-target-for-python-bindings.patch
@@ -1,4 +1,4 @@
-From 3b3e9d4844fc92cabf5ed86806cf2fd4df3c2543 Mon Sep 17 00:00:00 2001
+From 6c0959c1b800995f78ad7a28041c608b964d6786 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sun, 14 Jul 2024 22:44:55 +1100
 Subject: [PATCH 4/9] enable windows as a target for python bindings
@@ -9,10 +9,10 @@ Subject: [PATCH 4/9] enable windows as a target for python bindings
  2 files changed, 3 deletions(-)
 
 diff --git a/python/BUILD.bazel b/python/BUILD.bazel
-index 0d2254394..537ac6992 100644
+index c0bf90214..9eafd65a1 100644
 --- a/python/BUILD.bazel
 +++ b/python/BUILD.bazel
-@@ -131,8 +131,6 @@ selects.config_setting_group(
+@@ -103,8 +103,6 @@ selects.config_setting_group(
  )
  
  _message_target_compatible_with = {
@@ -22,10 +22,10 @@ index 0d2254394..537ac6992 100644
  }
  
 diff --git a/python/dist/BUILD.bazel b/python/dist/BUILD.bazel
-index ee07c735e..b6ddf9231 100644
+index d1b654844..c40bd66ac 100644
 --- a/python/dist/BUILD.bazel
 +++ b/python/dist/BUILD.bazel
-@@ -352,7 +352,6 @@ py_wheel(
+@@ -373,7 +373,6 @@ py_wheel(
          "src/",
      ],
      target_compatible_with = select({

--- a/recipe/patches/0005-Support-more-architectures-for-Python-bindings.patch
+++ b/recipe/patches/0005-Support-more-architectures-for-Python-bindings.patch
@@ -1,33 +1,14 @@
-From 83d0651291523406837168ce7e4e2197560c7606 Mon Sep 17 00:00:00 2001
+From 2cf684ac1cb36ab70183461ff0b7f8dc0189d569 Mon Sep 17 00:00:00 2001
 From: "Uwe L. Korn" <uwe.korn@quantco.com>
 Date: Mon, 16 Sep 2024 11:49:04 +0200
 Subject: [PATCH 5/9] Support more architectures for Python bindings
 
 ---
- WORKSPACE            | 6 +++---
  python/dist/dist.bzl | 6 ++++--
- 2 files changed, 7 insertions(+), 5 deletions(-)
+ 1 file changed, 4 insertions(+), 2 deletions(-)
 
-diff --git a/WORKSPACE b/WORKSPACE
-index 1652c799f..0e521e4ab 100644
---- a/WORKSPACE
-+++ b/WORKSPACE
-@@ -29,10 +29,10 @@ pip_install_dependencies()
- http_archive(
-     name = "platforms",
-     urls = [
--        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.7/platforms-0.0.7.tar.gz",
--        "https://github.com/bazelbuild/platforms/releases/download/0.0.7/platforms-0.0.7.tar.gz",
-+        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
-+        "https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
-     ],
--    sha256 = "3a561c99e7bdbe9173aa653fd579fe849f1d8d67395780ab4770b1f381431d51",
-+    sha256 = "218efe8ee736d26a3572663b374a253c012b716d8af0c07e842e82f238a0a7ee",
- )
- 
- http_archive(
 diff --git a/python/dist/dist.bzl b/python/dist/dist.bzl
-index 061125ede..9f9316f5c 100644
+index 7c9095e26..4034e7c9a 100644
 --- a/python/dist/dist.bzl
 +++ b/python/dist/dist.bzl
 @@ -5,12 +5,12 @@ load("@system_python//:version.bzl", "SYSTEM_PYTHON_VERSION")
@@ -53,4 +34,4 @@ index 061125ede..9f9316f5c 100644
 +            "ppc": "powerpc64le-linux-gnu",
              "linux-x86_64": "x86_64-linux-gnu",
              "k8": "x86_64-linux-gnu",
-         }
+             "s390x": "s390x-linux-gnu",

--- a/recipe/patches/0006-Compatible-windows-changes.patch
+++ b/recipe/patches/0006-Compatible-windows-changes.patch
@@ -1,27 +1,18 @@
-From 01002619993ed15a025da7ccc9e08b2d3953b30b Mon Sep 17 00:00:00 2001
+From cf688ff027fde906b91e72ebd673f7fe798784bb Mon Sep 17 00:00:00 2001
 From: "Uwe L. Korn" <uwe.korn@quantco.com>
 Date: Tue, 17 Sep 2024 22:29:40 +0200
 Subject: [PATCH 6/9] Compatible windows changes
 
 ---
- python/BUILD.bazel             |  7 ++++---
- python/descriptor.c            |  2 +-
- python/descriptor_containers.c | 10 +++++-----
- python/descriptor_pool.c       |  2 +-
- python/extension_dict.c        |  4 ++--
- python/map.c                   |  4 ++--
- python/message.c               |  2 +-
- python/protobuf.c              |  2 +-
- python/py_extension.bzl        |  5 ++++-
- python/repeated.c              |  2 +-
- python/unknown_fields.c        |  2 +-
- 11 files changed, 23 insertions(+), 19 deletions(-)
+ python/BUILD.bazel      | 7 ++++---
+ python/py_extension.bzl | 5 ++++-
+ 2 files changed, 8 insertions(+), 4 deletions(-)
 
 diff --git a/python/BUILD.bazel b/python/BUILD.bazel
-index 537ac6992..eeea16b8b 100644
+index 9eafd65a1..09573f6f3 100644
 --- a/python/BUILD.bazel
 +++ b/python/BUILD.bazel
-@@ -166,11 +166,12 @@ exports_files(["version_script.lds"])
+@@ -138,11 +138,12 @@ exports_files(["version_script.lds"])
  py_extension(
      name = "_message",
      srcs = [":message_srcs"],
@@ -37,153 +28,8 @@ index 537ac6992..eeea16b8b 100644
      target_compatible_with = select(_message_target_compatible_with),
      deps = [
          "//src/google/protobuf:descriptor_upb_reflection_proto",
-diff --git a/python/descriptor.c b/python/descriptor.c
-index ebd384e92..b79079315 100644
---- a/python/descriptor.c
-+++ b/python/descriptor.c
-@@ -23,7 +23,7 @@
- // This representation is used by all concrete descriptors.
- 
- typedef struct {
--  PyObject_HEAD;
-+  PyObject_HEAD
-   PyObject* pool;          // We own a ref.
-   const void* def;         // Type depends on the class. Kept alive by "pool".
-   PyObject* options;       // NULL if not present or not cached.
-diff --git a/python/descriptor_containers.c b/python/descriptor_containers.c
-index 05751a0f8..2b36cea9a 100644
---- a/python/descriptor_containers.c
-+++ b/python/descriptor_containers.c
-@@ -29,7 +29,7 @@ err:
- // -----------------------------------------------------------------------------
- 
- typedef struct {
--  PyObject_HEAD;
-+  PyObject_HEAD
-   const PyUpb_ByNameMap_Funcs* funcs;
-   const void* parent;    // upb_MessageDef*, upb_DefPool*, etc.
-   PyObject* parent_obj;  // Python object that keeps parent alive, we own a ref.
-@@ -89,7 +89,7 @@ static PyType_Spec PyUpb_ByNameIterator_Spec = {
- // -----------------------------------------------------------------------------
- 
- typedef struct {
--  PyObject_HEAD;
-+  PyObject_HEAD
-   const PyUpb_ByNumberMap_Funcs* funcs;
-   const void* parent;    // upb_MessageDef*, upb_DefPool*, etc.
-   PyObject* parent_obj;  // Python object that keeps parent alive, we own a ref.
-@@ -149,7 +149,7 @@ static PyType_Spec PyUpb_ByNumberIterator_Spec = {
- // -----------------------------------------------------------------------------
- 
- typedef struct {
--  PyObject_HEAD;
-+  PyObject_HEAD
-   const PyUpb_GenericSequence_Funcs* funcs;
-   const void* parent;    // upb_MessageDef*, upb_DefPool*, etc.
-   PyObject* parent_obj;  // Python object that keeps parent alive, we own a ref.
-@@ -342,7 +342,7 @@ static PyType_Spec PyUpb_GenericSequence_Spec = {
- // -----------------------------------------------------------------------------
- 
- typedef struct {
--  PyObject_HEAD;
-+  PyObject_HEAD
-   const PyUpb_ByNameMap_Funcs* funcs;
-   const void* parent;    // upb_MessageDef*, upb_DefPool*, etc.
-   PyObject* parent_obj;  // Python object that keeps parent alive, we own a ref.
-@@ -556,7 +556,7 @@ static PyType_Spec PyUpb_ByNameMap_Spec = {
- // -----------------------------------------------------------------------------
- 
- typedef struct {
--  PyObject_HEAD;
-+  PyObject_HEAD
-   const PyUpb_ByNumberMap_Funcs* funcs;
-   const void* parent;    // upb_MessageDef*, upb_DefPool*, etc.
-   PyObject* parent_obj;  // Python object that keeps parent alive, we own a ref.
-diff --git a/python/descriptor_pool.c b/python/descriptor_pool.c
-index cb79f8995..e20ba9a94 100644
---- a/python/descriptor_pool.c
-+++ b/python/descriptor_pool.c
-@@ -22,7 +22,7 @@
- // -----------------------------------------------------------------------------
- 
- typedef struct {
--  PyObject_HEAD;
-+  PyObject_HEAD
-   upb_DefPool* symtab;
-   PyObject* db;  // The DescriptorDatabase underlying this pool.  May be NULL.
- } PyUpb_DescriptorPool;
-diff --git a/python/extension_dict.c b/python/extension_dict.c
-index 34e1f9bd2..80ad1e985 100644
---- a/python/extension_dict.c
-+++ b/python/extension_dict.c
-@@ -16,7 +16,7 @@
- // -----------------------------------------------------------------------------
- 
- typedef struct {
--  PyObject_HEAD;
-+  PyObject_HEAD
-   PyObject* msg;  // Owning ref to our parent pessage.
- } PyUpb_ExtensionDict;
- 
-@@ -168,7 +168,7 @@ static PyType_Spec PyUpb_ExtensionDict_Spec = {
- // -----------------------------------------------------------------------------
- 
- typedef struct {
--  PyObject_HEAD;
-+  PyObject_HEAD
-   PyObject* msg;
-   size_t iter;
- } PyUpb_ExtensionIterator;
-diff --git a/python/map.c b/python/map.c
-index 1e2b3806b..5cc5aa534 100644
---- a/python/map.c
-+++ b/python/map.c
-@@ -18,7 +18,7 @@
- // -----------------------------------------------------------------------------
- 
- typedef struct {
--  PyObject_HEAD;
-+  PyObject_HEAD
-   PyObject* arena;
-   // The field descriptor (upb_FieldDef*).
-   // The low bit indicates whether the container is reified (see ptr below).
-@@ -410,7 +410,7 @@ static PyType_Spec PyUpb_MessageMapContainer_Spec = {
- // -----------------------------------------------------------------------------
- 
- typedef struct {
--  PyObject_HEAD;
-+  PyObject_HEAD
-   PyUpb_MapContainer* map;  // We own a reference.
-   size_t iter;
-   int version;
-diff --git a/python/message.c b/python/message.c
-index 5ad1b06eb..08ecb9f4c 100644
---- a/python/message.c
-+++ b/python/message.c
-@@ -177,7 +177,7 @@ err:
- // The parent may also be non-present, in which case a mutation will trigger a
- // chain reaction.
- typedef struct PyUpb_Message {
--  PyObject_HEAD;
-+  PyObject_HEAD
-   PyObject* arena;
-   uintptr_t def;  // Tagged, low bit 1 == upb_FieldDef*, else upb_MessageDef*
-   union {
-diff --git a/python/protobuf.c b/python/protobuf.c
-index 88e478d3c..498b13b43 100644
---- a/python/protobuf.c
-+++ b/python/protobuf.c
-@@ -199,7 +199,7 @@ PyObject* PyUpb_ObjCache_Get(const void* key) {
- // -----------------------------------------------------------------------------
- 
- typedef struct {
--  PyObject_HEAD;
-+  PyObject_HEAD
-   upb_Arena* arena;
- } PyUpb_Arena;
- 
 diff --git a/python/py_extension.bzl b/python/py_extension.bzl
-index 2741cdf6e..5fc2161e3 100644
+index 2afae61df..0a98ab349 100644
 --- a/python/py_extension.bzl
 +++ b/python/py_extension.bzl
 @@ -16,7 +16,10 @@ def py_extension(name, srcs, copts, deps = [], **kwargs):
@@ -198,29 +44,3 @@ index 2741cdf6e..5fc2161e3 100644
          linkopts = selects.with_or({
              (
                  "//python/dist:osx_x86_64",
-diff --git a/python/repeated.c b/python/repeated.c
-index 7940b4d36..0f0904a8b 100644
---- a/python/repeated.c
-+++ b/python/repeated.c
-@@ -18,7 +18,7 @@ static PyObject* PyUpb_RepeatedScalarContainer_Append(PyObject* _self,
- 
- // Wrapper for a repeated field.
- typedef struct {
--  PyObject_HEAD;
-+  PyObject_HEAD
-   PyObject* arena;
-   // The field descriptor (PyObject*).
-   // The low bit indicates whether the container is reified (see ptr below).
-diff --git a/python/unknown_fields.c b/python/unknown_fields.c
-index 8017bd894..177d36ff7 100644
---- a/python/unknown_fields.c
-+++ b/python/unknown_fields.c
-@@ -18,7 +18,7 @@
- // -----------------------------------------------------------------------------
- 
- typedef struct {
--  PyObject_HEAD;
-+  PyObject_HEAD
-   PyObject* fields;
- } PyUpb_UnknownFieldSet;
- 

--- a/recipe/patches/0007-Hacky-windows-workarounds.patch
+++ b/recipe/patches/0007-Hacky-windows-workarounds.patch
@@ -1,4 +1,4 @@
-From 7177923e7b81624e7be64a8e032b79577dab8d6d Mon Sep 17 00:00:00 2001
+From 63b165ec47bb36682fca0ff0ec3688904383dfca Mon Sep 17 00:00:00 2001
 From: "Uwe L. Korn" <uwe.korn@quantco.com>
 Date: Wed, 18 Sep 2024 11:54:27 +0200
 Subject: [PATCH 7/9] Hacky windows workarounds
@@ -10,7 +10,7 @@ Subject: [PATCH 7/9] Hacky windows workarounds
  3 files changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/python/dist/system_python.bzl b/python/dist/system_python.bzl
-index 9367dd00f..e89719405 100644
+index 390bf3c2a..901d974cc 100644
 --- a/python/dist/system_python.bzl
 +++ b/python/dist/system_python.bzl
 @@ -156,12 +156,12 @@ def register_system_python():
@@ -38,10 +38,10 @@ index 9367dd00f..e89719405 100644
  
      if path and python_version[0] == "3":
 diff --git a/python/message.c b/python/message.c
-index 08ecb9f4c..1aa2fbea3 100644
+index 3fe7480a6..85a893c14 100644
 --- a/python/message.c
 +++ b/python/message.c
-@@ -1018,7 +1018,7 @@ int PyUpb_Message_GetVersion(PyObject* _self) {
+@@ -1025,7 +1025,7 @@ int PyUpb_Message_GetVersion(PyObject* _self) {
   * Attribute lookup must find both message fields and base class methods like
   * msg.SerializeToString().
   */
@@ -51,14 +51,14 @@ index 08ecb9f4c..1aa2fbea3 100644
    PyUpb_Message* self = (void*)_self;
  
 diff --git a/python/protobuf.c b/python/protobuf.c
-index 498b13b43..0b2f5fed0 100644
+index 12b5f4493..9626a6574 100644
 --- a/python/protobuf.c
 +++ b/python/protobuf.c
-@@ -399,7 +399,7 @@ bool PyUpb_IndexToRange(PyObject* index, Py_ssize_t size, Py_ssize_t* i,
+@@ -401,7 +401,7 @@ bool PyUpb_IndexToRange(PyObject* index, Py_ssize_t size, Py_ssize_t* i,
  // Module Entry Point
  // -----------------------------------------------------------------------------
  
--__attribute__((visibility("default"))) PyMODINIT_FUNC PyInit__message(void) {
+-PyMODINIT_FUNC PyInit__message(void) {
 +__declspec(dllexport) PyMODINIT_FUNC PyInit__message(void) {
    PyObject* m = PyModule_Create(&module_def);
    if (!m) return NULL;

--- a/recipe/patches/0008-Add-osx-64-and-linux-ppc64le-as-supported-wheel-tags.patch
+++ b/recipe/patches/0008-Add-osx-64-and-linux-ppc64le-as-supported-wheel-tags.patch
@@ -1,4 +1,4 @@
-From 2043e08603619fff553c32a3734fd43153a814ae Mon Sep 17 00:00:00 2001
+From 113732b0d23ab8909c94183c033b663217c839c1 Mon Sep 17 00:00:00 2001
 From: Uwe Korn <uwelk@xhochy.com>
 Date: Mon, 23 Sep 2024 11:59:53 +0000
 Subject: [PATCH 8/9] Add osx-64 and linux-ppc64le as supported wheel tags
@@ -8,7 +8,7 @@ Subject: [PATCH 8/9] Add osx-64 and linux-ppc64le as supported wheel tags
  1 file changed, 22 insertions(+)
 
 diff --git a/python/dist/BUILD.bazel b/python/dist/BUILD.bazel
-index b6ddf9231..b229a876e 100644
+index c40bd66ac..809b1faf0 100644
 --- a/python/dist/BUILD.bazel
 +++ b/python/dist/BUILD.bazel
 @@ -65,6 +65,25 @@ config_setting(
@@ -37,7 +37,7 @@ index b6ddf9231..b229a876e 100644
  config_setting(
      name = "linux_x86_64_release",
      flag_values = {
-@@ -326,9 +345,12 @@ py_wheel(
+@@ -346,11 +365,14 @@ py_wheel(
      platform = select({
          ":linux_x86_64_local": "linux_x86_64",
          ":linux_x86_64_release": "manylinux2014_x86_64",
@@ -45,6 +45,8 @@ index b6ddf9231..b229a876e 100644
 +        ":linux_ppc64le_release": "manylinux2014_ppc64le",
          ":linux_aarch64_local": "linux_aarch64",
          ":linux_aarch64_release": "manylinux2014_aarch64",
+         ":linux_s390x_local_unused": "linux_s390x",
+         ":linux_s390x_release_unused": "manylinux2014_s390x",
          ":osx_universal2": "macosx_10_9_universal2",
 +        ":osx_x86_64": "macosx_10_13_x86_64",
          ":osx_aarch64": "macosx_11_0_arm64",

--- a/recipe/patches/0009-unvendor-abseil-zlib.patch
+++ b/recipe/patches/0009-unvendor-abseil-zlib.patch
@@ -1,66 +1,23 @@
-From 60eef3146b2cf518b5b81afd1e6a3563899d3d11 Mon Sep 17 00:00:00 2001
+From d5f0caca1b2e6766a473df6a11d59f8236d8cbeb Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Mon, 3 Mar 2025 11:59:27 +1100
 Subject: [PATCH 9/9] unvendor abseil/zlib
 
 depends on putting tensorflow infrastructure in place, see feedstock build scripts
 ---
- BUILD.bazel             |  1 -
- MODULE.bazel            | 11 ------
  WORKSPACE               | 15 +++++++++
- protobuf_deps.bzl       | 22 ------------
+ protobuf_deps.bzl       | 20 -----------
  python/BUILD.bazel      |  7 ++++
  third_party/BUILD.bazel |  1 -
  third_party/zlib.BUILD  | 74 -----------------------------------------
- 7 files changed, 22 insertions(+), 109 deletions(-)
+ 5 files changed, 22 insertions(+), 95 deletions(-)
  delete mode 100644 third_party/zlib.BUILD
 
-diff --git a/BUILD.bazel b/BUILD.bazel
-index 32b26cbdc..a17c11727 100644
---- a/BUILD.bazel
-+++ b/BUILD.bazel
-@@ -669,7 +669,6 @@ pkg_files(
-         "generate_descriptor_proto.sh",
-         "maven_install.json",
-         "//third_party:BUILD.bazel",
--        "//third_party:zlib.BUILD",
-     ],
-     strip_prefix = strip_prefix.from_root(""),
-     visibility = ["//pkg:__pkg__"],
-diff --git a/MODULE.bazel b/MODULE.bazel
-index 9de6ae3d3..a37c4d9c3 100644
---- a/MODULE.bazel
-+++ b/MODULE.bazel
-@@ -12,12 +12,6 @@ module(
- # Bzlmod follows MVS:
- # https://bazel.build/versions/6.0.0/build/bzlmod#version-resolution
- # Thus the highest version in their module graph is resolved.
--bazel_dep(
--    name = "abseil-cpp",
--    version = "20230802.0.bcr.1",
--    repo_name = "com_google_absl",
--)
--
- bazel_dep(
-     name = "bazel_skylib",
-     version = "1.7.0",
-@@ -73,11 +67,6 @@ bazel_dep(
-     version = "0.0.8",
- )
- 
--bazel_dep(
--    name = "zlib",
--    version = "1.3.1",
--)
--
- bazel_dep(
-     name = "bazel_features",
-     version = "1.17.0",
 diff --git a/WORKSPACE b/WORKSPACE
-index 0e521e4ab..f752fc57e 100644
+index b1030fa78..a7f1b912a 100644
 --- a/WORKSPACE
 +++ b/WORKSPACE
-@@ -7,6 +7,21 @@ local_repository(name = "com_google_protobuf", path = ".")
+@@ -10,6 +10,21 @@ local_repository(
  
  load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
  
@@ -79,31 +36,29 @@ index 0e521e4ab..f752fc57e 100644
 +    urls = tf_mirror_urls("https://zlib.net/fossils/zlib-1.3.1.tar.gz"),
 +)
 +
- local_repository(
-     name = "com_google_protobuf_examples",
-     path = "examples",
+ # Load common dependencies first to ensure we use the correct version
+ load("//:protobuf_deps.bzl", "PROTOBUF_MAVEN_ARTIFACTS", "protobuf_deps")
+ 
 diff --git a/protobuf_deps.bzl b/protobuf_deps.bzl
-index 3ada3d45f..1f495c5a6 100644
+index 86b343dbb..eeed873d2 100644
 --- a/protobuf_deps.bzl
 +++ b/protobuf_deps.bzl
-@@ -58,28 +58,6 @@ def protobuf_deps():
+@@ -71,26 +71,6 @@ def protobuf_deps():
              ],
          )
  
--    if not native.existing_rule("com_google_absl"):
+-    if not native.existing_rule("abseil-cpp"):
 -        _github_archive(
--            name = "com_google_absl",
+-            name = "abseil-cpp",
 -            repo = "https://github.com/abseil/abseil-cpp",
--            # TODO: use Layout::WithStaticSizes in SerialArenaChunk when we update
--            # abseil to new release.
--            commit = "4a2c63365eff8823a5221db86ef490e828306f9d",  # Abseil LTS 20240116.0
--            sha256 = "f49929d22751bf70dd61922fb1fd05eb7aec5e7a7f870beece79a6e28f0a06c1",
+-            commit = "9ac7062b1860d895fb5a8cbf58c3e9ef8f674b5f",  # Abseil LTS 20250127
+-            sha256 = "d8ae9aa794a571ee39c77085ee69f1d4ac276212a7d99734974d95df7baa8d13",
 -        )
 -
 -    if not native.existing_rule("zlib"):
 -        http_archive(
 -            name = "zlib",
--            build_file = Label("//:third_party/zlib.BUILD"),
+-            build_file = Label("//third_party:zlib.BUILD"),
 -            sha256 = "38ef96b8dfe510d42707d9c781877914792541133e1870841463bfa73f883e32",
 -            strip_prefix = "zlib-1.3.1",
 -            urls = [
@@ -116,10 +71,10 @@ index 3ada3d45f..1f495c5a6 100644
          _github_archive(
              name = "jsoncpp",
 diff --git a/python/BUILD.bazel b/python/BUILD.bazel
-index eeea16b8b..a9972aa85 100644
+index 09573f6f3..829a0a192 100644
 --- a/python/BUILD.bazel
 +++ b/python/BUILD.bazel
-@@ -21,6 +21,13 @@ package(
+@@ -20,6 +20,13 @@ package(
      default_visibility = ["//python/dist:__pkg__"],
  )
  
@@ -131,15 +86,15 @@ index eeea16b8b..a9972aa85 100644
 +)
 +
  LIMITED_API_FLAG_SELECT = {
-     ":limited_api_3.8": ["-DPy_LIMITED_API=0x03080000"],
+     ":limited_api_3.9": ["-DPy_LIMITED_API=0x03090000"],
      ":limited_api_3.10": ["-DPy_LIMITED_API=0x030a0000"],
 diff --git a/third_party/BUILD.bazel b/third_party/BUILD.bazel
-index 35da5c30f..f2fb7c709 100644
+index f70d91de5..491a5c5c7 100644
 --- a/third_party/BUILD.bazel
 +++ b/third_party/BUILD.bazel
-@@ -1,5 +1,4 @@
- exports_files([
+@@ -2,5 +2,4 @@ exports_files([
      "BUILD.bazel",
+     "jsoncpp.BUILD",
      "rules_fuzzing.patch",
 -    "zlib.BUILD",
  ])


### PR DESCRIPTION
Not sure why the bot didn't open any version PRs. Status page says the error was:
```
  File "/opt/autotick-bot/conda_forge_tick/migrators/version.py", line 324, in migrate
    raise VersionMigrationError(
conda_forge_tick.migrators.version.VersionMigrationError: The recipe did not change in the version migration, a URL did not hash, or there is jinja2 syntax the bot cannot handle!

Please check the URLs in your recipe with version '30.2' to make sure they exist!

We also found the following errors:

 - no URLs in the source section
 ```
 
 Yes, the major version changed, but that's why we're specifically only using the the part without it
https://github.com/conda-forge/protobuf-feedstock/blob/63a5a35808e7fc553093668b2412e36c9de5b334/recipe/meta.yaml#L1-L2